### PR TITLE
added format argument to specify alternative output format

### DIFF
--- a/NSDate+PrettyTimestamp.h
+++ b/NSDate+PrettyTimestamp.h
@@ -52,4 +52,14 @@
  */
 - (NSString*)prettyTimestampSinceDate:(NSDate*)date;
 
+/**
+ Timestamp between the date provided and the receiver, using the given format
+ @param date The date to compare to the receiver
+ @param format The format to print in. Format options are: %d for duration, e.g. "4"; %i for interval, e.g. "weeks"; %c for constant, e.g. "ago".
+ Any other characters in the format will be left untouched, i.e. they will appear in the output.
+ @note Use this method if you don't want the default format (e.g. "4 weeks ago"), for example, if you don't want spaces between the components, or if you want to add other decorative text.
+ @return lowercase string in the given format, see readme for examples
+ */
+- (NSString*)prettyTimestampSinceDate:(NSDate*)date withFormat:(NSString *)format;
+
 @end

--- a/NSDate+PrettyTimestamp.h
+++ b/NSDate+PrettyTimestamp.h
@@ -55,9 +55,10 @@
 /**
  Timestamp between the date provided and the receiver, using the given format
  @param date The date to compare to the receiver
- @param format The format to print in. Format options are: %d for duration, e.g. "4"; %i for interval, e.g. "weeks"; %c for constant, e.g. "ago".
+ @param format The format to print in. Format options are: %i for interval, e.g. "4"; %u for unit, e.g. "weeks"; %c for constant, e.g. "ago".
  Any other characters in the format will be left untouched, i.e. they will appear in the output.
- @note Use this method if you don't want the default format (e.g. "4 weeks ago"), for example, if you don't want spaces between the components, or if you want to add other decorative text.
+ If the format is nil, then the default format is used, i.e. "%i %u %c", e.g. "4 weeks ago"
+ @note Use this method if you don't want the default format, for example, if you don't want spaces between the components, or if you want to add other decorative text.
  @return lowercase string in the given format, see readme for examples
  */
 - (NSString*)prettyTimestampSinceDate:(NSDate*)date withFormat:(NSString *)format;

--- a/NSDate+PrettyTimestamp.m
+++ b/NSDate+PrettyTimestamp.m
@@ -46,6 +46,11 @@
 
 - (NSString*)prettyTimestampSinceDate:(NSDate*)date
 {
+  return [self prettyTimestampSinceDate:date withFormat:@"%d %i %c"]; // format is e.g. "4 weeks ago"
+}
+
+- (NSString*)prettyTimestampSinceDate:(NSDate*)date withFormat:(NSString *)format
+{
   NSCalendar *calendar = [NSCalendar currentCalendar];
   NSUInteger unitFlags = NSMinuteCalendarUnit | NSHourCalendarUnit | NSDayCalendarUnit | NSWeekCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit;
   NSDate *earliest = [self earlierDate:date];
@@ -56,27 +61,31 @@
     return NSLocalizedString(@"over a year ago", nil);
   }
   if (components.month >= 1) {
-    return [self stringForComponentValue:components.month withName:@"month" andPlural:@"months"];
+    return [self stringForComponentValue:components.month withName:@"month" andPlural:@"months" format:format];
   }
   if (components.week >= 1) {
-    return [self stringForComponentValue:components.week withName:@"week" andPlural:@"weeks"];
+    return [self stringForComponentValue:components.week withName:@"week" andPlural:@"weeks" format:format];
   }
   if (components.day >= 1) {
-    return [self stringForComponentValue:components.day withName:@"day" andPlural:@"days"];
+    return [self stringForComponentValue:components.day withName:@"day" andPlural:@"days" format:format];
   }
   if (components.hour >= 1) {
-    return [self stringForComponentValue:components.hour withName:@"hour" andPlural:@"hours"];
+    return [self stringForComponentValue:components.hour withName:@"hour" andPlural:@"hours" format:format];
   }
   if (components.minute >= 1) {
-    return [self stringForComponentValue:components.minute withName:@"minute" andPlural:@"minutes"];
+    return [self stringForComponentValue:components.minute withName:@"minute" andPlural:@"minutes" format:format];
   }
   return NSLocalizedString(@"just now", nil);
 }
 
-- (NSString*)stringForComponentValue:(NSInteger)componentValue withName:(NSString*)name andPlural:(NSString*)plural
+- (NSString*)stringForComponentValue:(NSInteger)componentValue withName:(NSString*)name andPlural:(NSString*)plural format:(NSString*)format
 {
   NSString *timespan = NSLocalizedString(componentValue == 1 ? name : plural, nil);
-  return [NSString stringWithFormat:@"%d %@ %@", componentValue, timespan, NSLocalizedString(@"ago", nil)];
+  [output replaceOccurrencesOfString:@"%d" withString:@(componentValue).stringValue options:0 range:NSMakeRange(0, output.length)];
+  [output replaceOccurrencesOfString:@"%i" withString:timespan options:0 range:NSMakeRange(0, output.length)];
+  [output replaceOccurrencesOfString:@"%c" withString:NSLocalizedString(@"ago", nil) options:0 range:NSMakeRange(0, output.length)];
+  
+  return output.copy;
 }
 
 @end

--- a/NSDate+PrettyTimestamp.m
+++ b/NSDate+PrettyTimestamp.m
@@ -46,7 +46,7 @@
 
 - (NSString*)prettyTimestampSinceDate:(NSDate*)date
 {
-  return [self prettyTimestampSinceDate:date withFormat:@"%d %i %c"]; // format is e.g. "4 weeks ago"
+  return [self prettyTimestampSinceDate:date withFormat:nil];
 }
 
 - (NSString*)prettyTimestampSinceDate:(NSDate*)date withFormat:(NSString *)format
@@ -56,6 +56,10 @@
   NSDate *earliest = [self earlierDate:date];
   NSDate *latest = (earliest == self) ? date : self;
   NSDateComponents *components = [calendar components:unitFlags fromDate:earliest toDate:latest options:0];
+  
+  if (!format) {
+    format = @"%i %u %c";
+  }
   
   if (components.year >= 1) {
     return NSLocalizedString(@"over a year ago", nil);
@@ -81,8 +85,10 @@
 - (NSString*)stringForComponentValue:(NSInteger)componentValue withName:(NSString*)name andPlural:(NSString*)plural format:(NSString*)format
 {
   NSString *timespan = NSLocalizedString(componentValue == 1 ? name : plural, nil);
-  [output replaceOccurrencesOfString:@"%d" withString:@(componentValue).stringValue options:0 range:NSMakeRange(0, output.length)];
-  [output replaceOccurrencesOfString:@"%i" withString:timespan options:0 range:NSMakeRange(0, output.length)];
+  
+  NSMutableString *output = format.mutableCopy;
+  [output replaceOccurrencesOfString:@"%i" withString:@(componentValue).stringValue options:0 range:NSMakeRange(0, output.length)];
+  [output replaceOccurrencesOfString:@"%u" withString:timespan options:0 range:NSMakeRange(0, output.length)];
   [output replaceOccurrencesOfString:@"%c" withString:NSLocalizedString(@"ago", nil) options:0 range:NSMakeRange(0, output.length)];
   
   return output.copy;


### PR DESCRIPTION
The reason I've added this is because the default format dictates that there should be spaces between the components, i.e. "4 weeks ago". But since I'm using the localization to replace "weeks" with "w", I want it to appear as "4w ago", for which I need to change the format.

This would also be useful in locales that might print it differently, for example, "depuis 4 semaines" (http://bit.ly/1GtxGwX)