### PR TITLE
Resolved iOS 8 Deprecations

### DIFF
--- a/NSDate+PrettyTimestamp.m
+++ b/NSDate+PrettyTimestamp.m
@@ -52,7 +52,7 @@
 - (NSString*)prettyTimestampSinceDate:(NSDate*)date withFormat:(NSString *)format
 {
   NSCalendar *calendar = [NSCalendar currentCalendar];
-  NSUInteger unitFlags = NSMinuteCalendarUnit | NSHourCalendarUnit | NSDayCalendarUnit | NSWeekCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit;
+  NSUInteger unitFlags = NSCalendarUnitMinute | NSCalendarUnitHour | NSCalendarUnitDay | NSCalendarUnitWeekOfYear | NSCalendarUnitMonth | NSCalendarUnitYear;
   NSDate *earliest = [self earlierDate:date];
   NSDate *latest = (earliest == self) ? date : self;
   NSDateComponents *components = [calendar components:unitFlags fromDate:earliest toDate:latest options:0];
@@ -67,8 +67,8 @@
   if (components.month >= 1) {
     return [self stringForComponentValue:components.month withName:@"month" andPlural:@"months" format:format];
   }
-  if (components.week >= 1) {
-    return [self stringForComponentValue:components.week withName:@"week" andPlural:@"weeks" format:format];
+  if (components.weekOfYear >= 1) {
+    return [self stringForComponentValue:components.weekOfYear withName:@"week" andPlural:@"weeks" format:format];
   }
   if (components.day >= 1) {
     return [self stringForComponentValue:components.day withName:@"day" andPlural:@"days" format:format];

--- a/PrettyTimestamp.podspec
+++ b/PrettyTimestamp.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = "PrettyTimestamp"
-  s.version      = "1.2"
+  s.version      = "1.2.1"
   s.summary      = "An NSDate Category that returns human readable, pretty timestamps between two dates. Now available with custom formatting."
   s.description  = <<-DESC
                     An NSDate Category that returns human readable, pretty timestamps between two dates. Now available with custom formatting thanks to Sam Dods.
-                    
+
                     # Examples
 
                     All returned strings are in lower case and plural / singular are handled
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.author       = { "Jon Hocking" => "hello@jonhocking.co.uk" }
   s.social_media_url = 'https://twitter.com/jonhocking'
-  s.source       = { :git => "https://github.com/jonhocking/PrettyTimestamp.git", :tag => "v1.2" }
+  s.source       = { :git => "https://github.com/jonhocking/PrettyTimestamp.git", :tag => "v1.2.1" }
   s.source_files = '*.{h,m}'
   s.requires_arc = true
   s.platform     = :ios


### PR DESCRIPTION
Changed constants that were deprecated in iOS 8 to ones that are not deprecated and the introduced in iOS 5 or earlier.  Also update the podspec to 1.2.1.
